### PR TITLE
Rename method in sample code. Add sentence to semaphore vs threadpool.

### DIFF
--- a/js/bulkhead-callback.js
+++ b/js/bulkhead-callback.js
@@ -250,7 +250,7 @@ var bulkheadCallBack = (function() {
             "      try {\n" +
             "        return serviceForVFA(counterForVFA);\n" +
             "      } catch {Exception ex} {\n" + 
-            "        handleBulkheadException();\n" +
+            "        handleException();\n" +
             "      }\n" +
             "      return null;\n" +
             "    });";

--- a/json-guides/bulkhead.json
+++ b/json-guides/bulkhead.json
@@ -26,7 +26,7 @@
                         "<h4>Bulkhead</h4>",
                         "The term <b>bulkhead</b> comes from the structure used in ships to create partitions. In the event of a hull breach, these partitions can be sealed off to prevent the rest of the ship from getting damaged.<br>",
                         "The bulkhead pattern in software systems works similarly by isolating failures to prevent the rest of the system from failing. There are two approaches to bulkhead: sempahore isolation and thread pool isolation.<br>",
-                        "With semaphore isolation, requests will fail upon exceeding the maximum concurrent requests. In thread pool isolation, extra requests are added to a waiting queue until currently running requests finish and free up space in the thread pool.",
+                        "With semaphore isolation, requests will fail upon exceeding the maximum concurrent requests. In thread pool isolation, extra requests are added to a waiting queue until currently running requests finish and free up space in the thread pool. Another advantage of the thread pool is allowing thread timeouts to free up resources from hanging threads.",
                         "<h4>Asynchronous</h4>",
                         "Asynchronous programming allows multiple tasks to run simultaneously, rather than waiting for a task to finish before executing the next. This is usually achieved by running tasks on separate threads."
                     ]
@@ -68,7 +68,7 @@
                 "<br>Let us start by adding Future and Executors to the code."
             ],
             "instruction": [
-                "Replace the <code>return serviceforVFA(counterForVFA);</code> on line 12 to the following block of code, or click <br><action title='Adding Java Concurrency' onclick=\"bulkheadCallBack.addJavaConcurrencyButton(event, 'AsyncWithoutBulkhead')\"><b>ExecutorService executor = Executors.newFixedThreadPool(1);\nFuture serviceRequest = executor.submit(() -> {\n  try{\n    return serviceForVFA(counterForVFA);\n  } catch {Exception ex} {\n    handleBulkheadException();\n  }\n  return null;\n});</b></action>.<br>Then, click <action title='Run' onclick=\"bulkheadCallBack.saveButtonEditorButton(event, 'AsyncWithoutBulkhead')\"><b>Run</b></action> on the editor menu pane.",
+                "Replace the <code>return serviceforVFA(counterForVFA);</code> on line 12 to the following block of code, or click <br><action title='Adding Java Concurrency' onclick=\"bulkheadCallBack.addJavaConcurrencyButton(event, 'AsyncWithoutBulkhead')\"><b>ExecutorService executor = Executors.newFixedThreadPool(1);\nFuture serviceRequest = executor.submit(() -> {\n  try{\n    return serviceForVFA(counterForVFA);\n  } catch {Exception ex} {\n    handleException();\n  }\n  return null;\n});</b></action>.<br>Then, click <action title='Run' onclick=\"bulkheadCallBack.saveButtonEditorButton(event, 'AsyncWithoutBulkhead')\"><b>Run</b></action> on the editor menu pane.",
                 "Click <action title='Customer 1 requests chat' onclick=\"bulkheadCallBack.clickChat(event, 'AsyncWithoutBulkhead')\"><b>Customer 1 requests chat</b></action> to open a chat session with a virtual financial advisor.<br>",
                 "While Customer 1 is still chatting with a financial advisor, click <action title='Customer 2 requests chat' onclick=\"bulkheadCallBack.clickChat(event, 'AsyncWithoutBulkhead')\"><b>Customer 2 requests chat</b></action> to open a separate chat session with a virtual financial advisor.<br>",
                 "Assume 97 more customers request chat sessions with a virtual financial advisor and all the sessions are still active.  Currently, the code does not implement a limit to the number of available advisor sessions. The system slowly runs out of CPU or memory resources causing it to overload.<br>Click <action title='Customer 100 requests chat' onclick=\"bulkheadCallBack.clickChat(event, 'AsyncWithoutBulkhead')\"><b>Customer 100 requests chat</b></action> to see the failure to open an additional chat session.<br>"
@@ -196,7 +196,7 @@
                                 "      try {",
                                 "        return serviceForVFA(counterForVFA);",
                                 "      } catch {Exception ex} {",
-                                "        handleBulkheadException();",
+                                "        handleException();",
                                 "      }",
                                 "      return null;",
                                 "    });",
@@ -269,7 +269,7 @@
                                 "      try {",
                                 "        return serviceForVFA(counterForVFA);",
                                 "      } catch {Exception ex} {",
-                                "        handleBulkheadException();",
+                                "        handleException();",
                                 "      }",
                                 "      return null;",
                                 "    });",


### PR DESCRIPTION
The Future/Executor step shouldnt have `handleBulkheadException()` because Bulkhead hasn't been used yet. Changing all steps to be consistent.