### PR TITLE
New title and description for bulkhead

### DIFF
--- a/html/bulkhead-guide.html
+++ b/html/bulkhead-guide.html
@@ -1,7 +1,7 @@
 ---
 layout: interactive-guide
-title: "Preventing cascading failures with Bulkhead"
-description: Learn how to use the MicroProfile Bulkhead policy to prevent cascading failures.
+title: "Limiting the number of concurrent requests to microservices"
+description: Use a MicroProfile Bulkhead policy to limit requests and prevent faults from cascading to the entire system.
 tags: ['Interactive', 'MicroProfile', 'Bulkhead', 'Async']
 css:
 - interactive-guides/main


### PR DESCRIPTION
Update bulkhead guide's title and description.  Take 'bulkhead' out of title, and move it to the description.