### PR TITLE
Dont let the x/x counters split across lines

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -4,6 +4,7 @@
     border-radius: 1px;
     height: 42px !important;
     margin-bottom: 2px !important;
+    width: 100%;
 }
 
 .chatSummary {

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -34,6 +34,7 @@
     line-height: 26px;
     text-align: left;
     margin: 8px 0 10px 10px;
+    white-space: nowrap;
 }
 
 .countTableCellLine {


### PR DESCRIPTION
Don't let the span's holding the x/xx counters in the dashboard be split when the screen size shrinks.

On IE, the dashboard was not expanding the full width of the column.   Adding width: 100% to the table of the dashboard fixed that in IE.