### PR TITLE
Changes to support accessibility with JAWS

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -127,10 +127,6 @@ body {
     font-size: 12px;
 }
 
-.spacing {
-    margin-top: 87px;
-}
-
 .errorTextBox {
     font-size: 16px;
     color :#272727;
@@ -138,6 +134,10 @@ body {
     line-height: 26px;
     margin: 0px 42px 0px 40px;
     text-align: center;
+}
+
+.spacing {
+    margin-top: 87px;
 }
 
 @keyframes blink {
@@ -254,7 +254,4 @@ body {
 .timeResponse {
     margin-top: 40px;
     display: none;
-}
-
-@media only screen and (max-width : 425px){
 }

--- a/html/virtual-financial-advisor-async-without-bulkhead.html
+++ b/html/virtual-financial-advisor-async-without-bulkhead.html
@@ -1,4 +1,4 @@
-<div id="asyncWithoutBulkheadStep" class="pod-animation-slide-from-right" tabindex="0">
+<div id="asyncWithoutBulkheadStep" class="pod-animation-slide-from-right" tabindex="0" aria-label="Virtual financial advisor sample browser window">
     <div class="dashboardContainer" style="visibility:hidden;"></div>   
     <div class='browserHolder'></div>
 </div>

--- a/html/virtual-financial-advisor-asyncbulkhead-fallback.html
+++ b/html/virtual-financial-advisor-asyncbulkhead-fallback.html
@@ -1,5 +1,5 @@
 <div id="asyncBulkheadFallbackStep" class="pod-animation-slide-from-right" tabindex="0">
-    <table class="dashboardContainer" tabindex="0">
+    <table class="dashboardContainer" tabindex="0" aria-label="Virtual Financial Advisor chat session summary">
         <tr class="chatSummary">
             <th class="countTableCellLine">
                 <span class="chatLabel">IN PROGRESS</span>

--- a/html/virtual-financial-advisor-asyncbulkhead-fallback.html
+++ b/html/virtual-financial-advisor-asyncbulkhead-fallback.html
@@ -1,16 +1,16 @@
-<div id="asyncBulkheadFallbackStep" class="pod-animation-slide-from-right" tabindex="0">
-    <table class="dashboardContainer" tabindex="0" aria-label="Virtual Financial Advisor chat session summary">
+<div id="asyncBulkheadFallbackStep" class="pod-animation-slide-from-right" tabindex="0" aria-label="Virtual financial advisor chat summary and sample browser window">
+    <table class="dashboardContainer" tabindex="0">
         <tr class="chatSummary">
             <th class="countTableCellLine">
-                <span class="chatLabel">IN PROGRESS</span>
-                <span class="chatCount">
+                <span class="chatLabel" aria-label="50 concurrent chats are allowed">IN PROGRESS</span>
+                <span class="chatCount busyChatCount" aria-label="No chat is in progress">
                     <span class="busyCount">0</span>
                         /50
                 </span>
             </th>
             <th class="countTableCellLine">
-                <span class="chatLabel">WAITING</span>
-                <span class="chatCount">
+                <span class="chatLabel" aria-label="50 chat requests are allowed in the waiting queue">WAITING</span>
+                <span class="chatCount waitChatCount" aria-label="No request is waiting in the queue">
                     <span class="waitCount">0</span>
                         /50
                 </span>

--- a/html/virtual-financial-advisor-asyncbulkhead-fallback.html
+++ b/html/virtual-financial-advisor-asyncbulkhead-fallback.html
@@ -1,6 +1,6 @@
 <div id="asyncBulkheadFallbackStep" class="pod-animation-slide-from-right" tabindex="0" aria-label="Virtual financial advisor chat summary and sample browser window">
-    <table class="dashboardContainer" tabindex="0">
-        <tr class="chatSummary">
+    <table class="dashboardContainer" tabindex="0" aria-label="Chat summary">
+        <tr class="chatSummary" tabindex="0">
             <th class="countTableCellLine">
                 <span class="chatLabel" aria-label="50 concurrent chats are allowed">IN PROGRESS</span>
                 <span class="chatCount busyChatCount" aria-label="No chat is in progress">

--- a/html/virtual-financial-advisor-asyncbulkhead-fallback.html
+++ b/html/virtual-financial-advisor-asyncbulkhead-fallback.html
@@ -1,5 +1,5 @@
 <div id="asyncBulkheadFallbackStep" class="pod-animation-slide-from-right" tabindex="0">
-    <table class="dashboardContainer">
+    <table class="dashboardContainer" tabindex="0">
         <tr class="chatSummary">
             <th class="countTableCellLine">
                 <span class="chatLabel">IN PROGRESS</span>

--- a/html/virtual-financial-advisor-asyncbulkhead.html
+++ b/html/virtual-financial-advisor-asyncbulkhead.html
@@ -1,5 +1,5 @@
 <div id="asyncBulkheadStep" class="pod-animation-slide-from-right" tabindex="0">
-    <table class="dashboardContainer" tabindex="0">
+    <table class="dashboardContainer" tabindex="0" aria-label="Virtual Financial Advisor chat session summary">
         <tr class="chatSummary">
             <th class="countTableCellLine">
                 <span class="chatLabel">IN PROGRESS</span>

--- a/html/virtual-financial-advisor-asyncbulkhead.html
+++ b/html/virtual-financial-advisor-asyncbulkhead.html
@@ -1,16 +1,16 @@
-<div id="asyncBulkheadStep" class="pod-animation-slide-from-right" tabindex="0">
-    <table class="dashboardContainer" tabindex="0" aria-label="Virtual Financial Advisor chat session summary">
+<div id="asyncBulkheadStep" class="pod-animation-slide-from-right" tabindex="0" aria-label="Virtual financial advisor chat summary and sample browser window">
+    <table class="dashboardContainer" tabindex="0">
         <tr class="chatSummary">
             <th class="countTableCellLine">
-                <span class="chatLabel">IN PROGRESS</span>
-                <span class="chatCount">
+                <span class="chatLabel" aria-label="50 concurrent chats are allowed">IN PROGRESS</span>
+                <span class="chatCount busyChatCount" aria-label="No chat is in progress">
                     <span class="busyCount">0</span>
                     /50
                 </span>
             </th>
             <th class="countTableCellLine">
-                <span class="chatLabel">WAITING</span>
-                <span class="chatCount">
+                <span class="chatLabel" aria-label="50 chat requests are allowed in the waiting queue">WAITING</span>
+                <span class="chatCount waitChatCount" aria-label="No request is waiting in the queue">
                     <span class="waitCount">0</span>
                     /50
                 </span>

--- a/html/virtual-financial-advisor-asyncbulkhead.html
+++ b/html/virtual-financial-advisor-asyncbulkhead.html
@@ -1,5 +1,5 @@
 <div id="asyncBulkheadStep" class="pod-animation-slide-from-right" tabindex="0">
-    <table class="dashboardContainer">
+    <table class="dashboardContainer" tabindex="0">
         <tr class="chatSummary">
             <th class="countTableCellLine">
                 <span class="chatLabel">IN PROGRESS</span>

--- a/html/virtual-financial-advisor-asyncbulkhead.html
+++ b/html/virtual-financial-advisor-asyncbulkhead.html
@@ -1,6 +1,6 @@
 <div id="asyncBulkheadStep" class="pod-animation-slide-from-right" tabindex="0" aria-label="Virtual financial advisor chat summary and sample browser window">
-    <table class="dashboardContainer" tabindex="0">
-        <tr class="chatSummary">
+    <table class="dashboardContainer" tabindex="0" aria-label="Chat summary">
+        <tr class="chatSummary" tabindex="0">
             <th class="countTableCellLine">
                 <span class="chatLabel" aria-label="50 concurrent chats are allowed">IN PROGRESS</span>
                 <span class="chatCount busyChatCount" aria-label="No chat is in progress">

--- a/html/virtual-financial-advisor-bulkhead-error.html
+++ b/html/virtual-financial-advisor-bulkhead-error.html
@@ -21,8 +21,6 @@
         <img class="chatIcon" src="/guides/draft-iguide-bulkhead/html/images/chat-icon.svg" alt="chat icon"/>
         <span class="chatIntroText">Chat with a financial advisor</span>
     </div>
-    <div class="spacing">
-        <p class="errorTextBox">All financial advisors are currently busy.<br>Please try again later.</p>
-    </div>
+    <div class="spacing errorTextBox">All financial advisors are currently busy.<br>Please try again later.</div>
 </body>
 </html>

--- a/html/virtual-financial-advisor-bulkhead.html
+++ b/html/virtual-financial-advisor-bulkhead.html
@@ -1,7 +1,7 @@
-<div id="bulkheadStep" class="pod-animation-slide-from-right" tabindex="0" aria-label="Virtual financial advisor chat summary and sample browser display content">
+<div id="bulkheadStep" class="pod-animation-slide-from-right" tabindex="0" aria-label="Virtual financial advisor chat summary and sample browser window">
     <!-- <div class="dashboardContainer"></div> -->
-    <table class="dashboardContainer" tabindex="0">
-        <tr class="chatSummary">          
+    <table class="dashboardContainer" tabindex="0" aria-label="Chat summary">
+        <tr class="chatSummary" tabindex="0">          
             <th class="oneCount" >
                 <span class="chatLabel" aria-label="50 concurrent chats are allowed">IN PROGRESS</span>
                 <span class="chatCount busyChatCount" aria-label="No chat is in progress">

--- a/html/virtual-financial-advisor-bulkhead.html
+++ b/html/virtual-financial-advisor-bulkhead.html
@@ -1,6 +1,6 @@
 <div id="bulkheadStep" class="pod-animation-slide-from-right" tabindex="0">
     <!-- <div class="dashboardContainer"></div> -->
-    <table class="dashboardContainer">
+    <table class="dashboardContainer" tabindex="0" aria-label="Virtual Financial Advisor chat session summary">
         <tr class="chatSummary">            
             <th class="oneCount">
                 <span class="chatLabel">IN PROGRESS</span>

--- a/html/virtual-financial-advisor-bulkhead.html
+++ b/html/virtual-financial-advisor-bulkhead.html
@@ -1,10 +1,10 @@
-<div id="bulkheadStep" class="pod-animation-slide-from-right" tabindex="0">
+<div id="bulkheadStep" class="pod-animation-slide-from-right" tabindex="0" aria-label="Virtual financial advisor chat summary and sample browser display content">
     <!-- <div class="dashboardContainer"></div> -->
-    <table class="dashboardContainer" tabindex="0" aria-label="Virtual Financial Advisor chat session summary">
-        <tr class="chatSummary">            
-            <th class="oneCount">
-                <span class="chatLabel">IN PROGRESS</span>
-                <span class="chatCount">
+    <table class="dashboardContainer" tabindex="0">
+        <tr class="chatSummary">          
+            <th class="oneCount" >
+                <span class="chatLabel" aria-label="50 concurrent chats are allowed">IN PROGRESS</span>
+                <span class="chatCount busyChatCount" aria-label="No chat is in progress">
                     <span class="busyCount">0</span>
                     /50
                 </span>

--- a/html/virtual-financial-advisor-chat.html
+++ b/html/virtual-financial-advisor-chat.html
@@ -35,7 +35,7 @@
         </div>
     </div>
     <div class="customerChatBlock flexContainer">
-        <input type="text" class="customerChatInput" value="For demo only and will not do anything"/>
+        <input type="text" class="customerChatInput" aria-label="Chat input from customer" value="For demo only and will not do anything"/>
         <button class="customerChatSubmitButton" title="For demo only and will not do anything">Submit</button>
     </div>
 </body>

--- a/html/virtual-financial-advisor-no-available.html
+++ b/html/virtual-financial-advisor-no-available.html
@@ -21,8 +21,6 @@
         <img class="chatIcon" src="/guides/draft-iguide-bulkhead/html/images/chat-icon.svg" alt="chat icon"/>
         <span class="chatIntroText">Chat with a financial advisor</span>
     </div>
-    <div class="spacing">
-        <p class="errorTextBox">The financial advisor is currently busy with a customer.<br>Please try again later.</p>
-    </div>
+    <div class="spacing errorTextBox">The financial advisor is currently busy with a customer.<br>Please try again later.</div>
 </body>
 </html>

--- a/js/bulkhead-callback.js
+++ b/js/bulkhead-callback.js
@@ -202,7 +202,7 @@ var bulkheadCallBack = (function() {
         } 
 
         if (__checkEditorContent(stepName, content)) {
-            //editor.closeEditorErrorBox(stepName);
+            editor.closeEditorErrorBox(stepName);
             var index = contentManager.getCurrentInstructionIndex();
             if(index === 0){
                 contentManager.markCurrentInstructionComplete(stepName);
@@ -539,6 +539,7 @@ var bulkheadCallBack = (function() {
             requestLimits = 2;
             if (requestNum === 1) {
                 $("#" + stepElementId).find(".busyCount").text('1');
+                $("#" + stepElementId).find(".busyChatCount").attr("aria-label", "1 chat is currently in progress");
             } else if (requestNum === requestLimits) {
                 browser.setBrowserContent("/guides/draft-iguide-bulkhead/html/virtual-financial-advisor-processing.html"); 
                 __incrementCounts(stepName, 2, 51, ".busyCount", browserErrorUrl, 
@@ -552,6 +553,7 @@ var bulkheadCallBack = (function() {
             requestLimits = 2;
             if (requestNum === 1) {
                 $("#" + stepElementId).find(".busyCount").text('1');
+                $("#" + stepElementId).find(".busyChatCount").attr("aria-label", "1 chat is currently in progress");
             } else if (requestNum === 2) {
                 browser.setBrowserContent("/guides/draft-iguide-bulkhead/html/virtual-financial-advisor-processing.html"); 
                 __incrementCounts(stepName, 2, 51, ".busyCount", __browserVirtualAdvisorBaseURL + "waitingqueue", 
@@ -570,6 +572,7 @@ var bulkheadCallBack = (function() {
             requestLimits = 2;
             if (requestNum === 1) {
                 $("#" + stepElementId).find(".busyCount").text('1');
+                $("#" + stepElementId).find(".busyChatCount").attr("aria-label", "1 chat is currently in progress");
             } else if (requestNum === 2) {
                 browser.setBrowserContent("/guides/draft-iguide-bulkhead/html/virtual-financial-advisor-processing.html"); 
                 __incrementCounts(stepName, 2, 51, ".busyCount", __browserVirtualAdvisorBaseURL + "waitingqueue", 
@@ -577,12 +580,12 @@ var bulkheadCallBack = (function() {
                 return;
             } else if (requestNum === 3) {
                 browser.getIframeDOM().find(".errorTextBox").hide();
-                __incrementCounts(stepName, 2, 51, ".waitCount", browserErrorUrl, 
+                __incrementCounts(stepName, 2, 51, ".waitCount", __browserVirtualAdvisorBaseURL + "scheduleAppointment", 
                                  "/guides/draft-iguide-bulkhead/html/virtual-financial-advisor-fallback.html");
                 return;
             } else if (requestNum > 3) {
                 browserContentHTML = "/guides/draft-iguide-bulkhead/html/virtual-financial-advisor-fallback.html";
-                browserUrl = __browserVirtualAdvisorBaseURL + "fallback";
+                browserUrl = __browserVirtualAdvisorBaseURL + "scheduleAppointment";
             }  
         }
 
@@ -618,6 +621,14 @@ var bulkheadCallBack = (function() {
                 browser.setBrowserContent(htmlForAfterCount);
                 if (startingWaitingQueue) {
                     $("#" + stepElementId).find(".waitCount").text(1);
+                    $("#" + stepElementId).find(".waitChatCount").attr("aria-label", "1 chat request is waiting in the queue");
+                    $("#" + stepElementId).find(".busyChatCount").attr("aria-label", "50 chats are currently in progress");
+                } else {
+                    if (elementToBeCounted === ".busyCount") {
+                        $("#" + stepElementId).find(".busyChatCount").attr("aria-label", "50 chats are currently in progress");
+                    } else {
+                        $("#" + stepElementId).find(".waitChatCount").attr("aria-label", "50 chat requests are waiting in the queue");
+                    }
                 }
             }
         }, 20);


### PR DESCRIPTION
- Add tabindex and aria-label to dashboard. Table is not recognized by the latest JAWS provided. To support two versions of JAWS with different table behavior, a screen reader will use two tabs in both versions. The first tab is to get the table aria-label. The second tab is to get the aria-label for the row. If arrow is used instead of table for the JAWS version that recognizes a table, the span text is read instead.
- Remove announcing of blank line by putting spacing class with errorTextBox class.
- Dismiss the validation alert in the editor.