### PR TITLE
Playground updates

### DIFF
--- a/css/bulkhead.css
+++ b/css/bulkhead.css
@@ -38,13 +38,16 @@
     
 .bulkheadRequestButtons {
     margin-top: 30px;
+    margin-bottom: 18px;
 }
 
 .bulkheadButton {
-    padding: 3px 12px;
+    padding: 0px;
     transition: all .2s;
-    border-radius: 100px;
-    width: 110px;
+    border-radius: 12px;
+    width: 99px;
+    height: 24px;
+    color: #24263B;
 }
 
 .bulkheadThreadRequestButton {
@@ -68,7 +71,7 @@
 
 .bulkheadResetButton {
     background-color: #BEBEBE;
-    margin-top: 10px;
+    margin-top: 12px;
 }
 .bulkheadResetButton:hover,
 .bulkheadResetButton:active,
@@ -77,7 +80,7 @@
 }
 
 .bulkheadQueueDiv {
-    margin-top: 30px;
+    padding-bottom: 20px;
 }
 
 .bulkheadQueue {
@@ -88,26 +91,16 @@
     white-space: nowrap;
 }
 
-.box {
-    width: 10px;
-    height: 10px;
-    display: inline-block;
-    margin-left: 2px;
-    margin-right: 2px;
+.queuePerson {
+    margin-right: 4px;
 }
 
-.threadpoolBox {
-    border: 1px solid #ABD155;
+.bulkheadExceptionDiv {
+    margin-top: 10px;
 }
 
-.threadpoolBoxInUse {
-    background-color: #ABD155;
-}
-
-.waitingTaskBox {
-    border: 1px solid #E3700D;
-}
-
-.waitingTaskBoxInUse {
-    background-color: #E3700D;
+.bulkheadException {
+    font-weight: 500;
+    color: #24263B;
+    line-height: 19px;
 }

--- a/css/bulkhead.css
+++ b/css/bulkhead.css
@@ -42,12 +42,10 @@
 }
 
 .bulkheadButton {
-    padding: 0px;
+    padding: 3px 12px;
     transition: all .2s;
-    border-radius: 12px;
-    width: 99px;
-    height: 24px;
-    color: #24263B;
+    border-radius: 100px;
+    width: 110px;
 }
 
 .bulkheadThreadRequestButton {

--- a/html/async-bulkhead-playground.html
+++ b/html/async-bulkhead-playground.html
@@ -18,7 +18,7 @@
         </div>
         <div class="bulkheadQueues">          
           <div class="bulkheadThreadpool bulkheadQueueDiv" tabindex='0'>
-            <span class="bulkheadThreadpoolQueueDescription">Thread pool queue representing the number of concurrent threads: </span>
+            <span class="bulkheadThreadpoolQueueDescription">Thread pool queue representing the number of chat requests: </span>
             <div class="bulkheadQueue bulkheadThreadpoolQueue"></div>
           </div>
           <div class="bulkheadWait bulkheadQueueDiv" tabindex='0'>

--- a/html/async-bulkhead-playground.html
+++ b/html/async-bulkhead-playground.html
@@ -15,34 +15,22 @@
         <div class="bulkheadRequestButtons">
           <button class="btn bulkheadButton bulkheadThreadRequestButton" title="Chat request">Chat Request</button>
           <button class="btn bulkheadButton bulkheadThreadReleaseButton" title="End chat">End Chat</button>          
-          <div>
-            <button class="btn bulkheadButton bulkheadResetButton" title="Reset">Reset</button>
-          </div>
         </div>
         <div class="bulkheadQueues">          
           <div class="bulkheadThreadpool bulkheadQueueDiv" tabindex='0'>
             <span class="bulkheadThreadpoolQueueDescription">Thread pool queue representing the number of concurrent threads: </span>
-            <div class="bulkheadQueue bulkheadThreadpoolQueue">[
-                    <div class="threadpoolBoxInUse box"></div>
-                    <div class="threadpoolBoxInUse box"></div>
-                    <div class="threadpoolBox box"></div>
-                    <div class="threadpoolBox box"></div>
-                    <div class="threadpoolBox box"></div>
-            ]</div>
+            <div class="bulkheadQueue bulkheadThreadpoolQueue"></div>
           </div>
           <div class="bulkheadWait bulkheadQueueDiv" tabindex='0'>
             <span class="bulkheadWaitQueueDescription">Waiting tasks queue: </span>
-            <div class="bulkheadQueue bulkheadWaitQueue">[
-                    <div class="waitingTaskBoxInUse box"></div>
-                    <div class="waitingTaskBox box"></div>
-                    <div class="waitingTaskBox box"></div>
-                    <div class="waitingTaskBox box"></div>
-                    <div class="waitingTaskBox box"></div>
-            ]</div>
+            <div class="bulkheadQueue bulkheadWaitQueue"></div>
           </div>
-          <div class="bulkheadDescriptionDiv bulkheadQueueDiv" style="display: none;" tabindex='0'>
+          <div class="bulkheadExceptionDiv" style="display: none;" tabindex='0'>
             <span class="bulkheadException">Exceeded wait queue size. Bulkhead Exception is thrown.</span>
           </div>
+          <div>
+              <button class="btn bulkheadButton bulkheadResetButton" title="Reset">Reset</button>
+          </div>  
         </div>
       </div>
 

--- a/html/images/user_green.svg
+++ b/html/images/user_green.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="11px" height="13px" viewBox="0 0 11 13" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>user_24</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="playground" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(-426.000000, -180.000000)">
+        <g id="user_24" transform="translate(426.000000, 180.000000)" fill="#ABD155" fill-rule="nonzero">
+            <g id="Icon">
+                <ellipse id="Oval" cx="5.5" cy="4.13636364" rx="4.27777778" ry="4.13636364"></ellipse>
+                <path d="M9.16666667,9.45454545 L1.83333333,9.45454545 C0.855555556,9.45454545 0,10.2818182 0,11.2272727 L0,13 L11,13 L11,11.2272727 C11,10.2818182 10.1444444,9.45454545 9.16666667,9.45454545 Z" id="Shape"></path>
+                <ellipse id="Oval" cx="5.5" cy="4.13636364" rx="4.27777778" ry="4.13636364"></ellipse>
+                <path d="M9.16666667,9.45454545 L1.83333333,9.45454545 C0.855555556,9.45454545 0,10.2818182 0,11.2272727 L0,13 L11,13 L11,11.2272727 C11,10.2818182 10.1444444,9.45454545 9.16666667,9.45454545 Z" id="Shape"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/html/images/user_orange.svg
+++ b/html/images/user_orange.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="11px" height="13px" viewBox="0 0 11 13" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>user_24 copy 4</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="playground" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(-426.000000, -241.000000)">
+        <g id="user_24-copy-4" transform="translate(426.000000, 241.000000)" fill="#E3700D" fill-rule="nonzero">
+            <g id="Icon">
+                <ellipse id="Oval" cx="5.5" cy="4.13636364" rx="4.27777778" ry="4.13636364"></ellipse>
+                <path d="M9.16666667,9.45454545 L1.83333333,9.45454545 C0.855555556,9.45454545 0,10.2818182 0,11.2272727 L0,13 L11,13 L11,11.2272727 C11,10.2818182 10.1444444,9.45454545 9.16666667,9.45454545 Z" id="Shape"></path>
+                <ellipse id="Oval" cx="5.5" cy="4.13636364" rx="4.27777778" ry="4.13636364"></ellipse>
+                <path d="M9.16666667,9.45454545 L1.83333333,9.45454545 C0.855555556,9.45454545 0,10.2818182 0,11.2272727 L0,13 L11,13 L11,11.2272727 C11,10.2818182 10.1444444,9.45454545 9.16666667,9.45454545 Z" id="Shape"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/html/images/user_outline-green.svg
+++ b/html/images/user_outline-green.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="11px" height="13px" viewBox="0 0 11 13" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>user_24 copy 3</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="playground-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(-506.000000, -180.000000)">
+        <g id="user_24-copy-3" transform="translate(506.000000, 180.000000)" fill-rule="nonzero" stroke="#ABD155">
+            <g id="Icon">
+                <ellipse id="Oval" cx="5.5" cy="4.13636364" rx="3.77777778" ry="3.63636364"></ellipse>
+                <path d="M0.5,12.5 L10.5,12.5 L10.5,11.2272727 C10.5,10.5617916 9.87199327,9.95454545 9.16666667,9.95454545 L1.83333333,9.95454545 C1.12800673,9.95454545 0.5,10.5617916 0.5,11.2272727 L0.5,12.5 Z" id="Shape"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/html/images/user_outline-orange.svg
+++ b/html/images/user_outline-orange.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="11px" height="13px" viewBox="0 0 11 13" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>user_24 copy 3</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="playground-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(-536.000000, -180.000000)">
+        <g id="user_24-copy-3" transform="translate(536.000000, 180.000000)" fill-rule="nonzero" stroke="#E3700D">
+            <g id="Icon">
+                <ellipse id="Oval" cx="5.5" cy="4.13636364" rx="3.77777778" ry="3.63636364"></ellipse>
+                <path d="M0.5,12.5 L10.5,12.5 L10.5,11.2272727 C10.5,10.5617916 9.87199327,9.95454545 9.16666667,9.95454545 L1.83333333,9.95454545 C1.12800673,9.95454545 0.5,10.5617916 0.5,11.2272727 L0.5,12.5 Z" id="Shape"></path>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
Playground updates according to playback feedback:

- Add new queue icons (little people) instead of boxes to represent the thread pool and waiting task queues.
- Update the label for the thread pool queue because of the switch to the little people.
- Refactor async-bulkhead.js for performance reasons.  The icons were taking much longer to draw than the colored divs representing the boxes used previously causing constant flicker, so had to rework how the icons were updated as the start and end chat buttons are selected.
- Relocate the **Reset** button to the bottom of the playground
- Updates to the playground's CSS as per design